### PR TITLE
Base infrastructure spin-up

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "docker:enableMajor",
+    ":disableRateLimiting",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":enablePreCommit",
+    ":automergeDigest",
+    ":automergeBranch",
+    "github>CloudHub-Social/CloudHub-Cluster-Temp//.github/renovate/autoMerge.json5",
+    "github>CloudHub-Social/CloudHub-Cluster-Temp//.github/renovate/commitMessage.json5",
+    "github>CloudHub-Social/CloudHub-Cluster-Temp//.github/renovate/groups.json5",
+    "github>CloudHub-Social/CloudHub-Cluster-Temp//.github/renovate/labels.json5",
+    "github>CloudHub-Social/CloudHub-Cluster-Temp//.github/renovate/semanticCommits.json5",
+    "helpers:pinGitHubActionDigests",
+    ":assignee(Just-Insane)",
+    ":reviewer(Just-Insane)"
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "suppressNotifications": ["prIgnoreNotification"],
+  "rebaseWhen": "conflicted",
+  "schedule": [
+    "after 9pm every weekday",
+    "before 6am every weekday",
+    "every weekend"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/production/**",
+    "**/staging/**"
+  ],
+  "pre-commit": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchSourceUrlPrefixes": [
+        "https://github.com/"
+      ],
+      "prBodyDefinitions": {
+        "OpenSSF": "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})"
+      },
+      "prBodyColumns": [
+        "Package",
+        "Type",
+        "Update",
+        "Change",
+        "Pending",
+        "OpenSSF"
+      ]
+    }
+  ],
+  "flux": {
+    "fileMatch": [
+      "kubernetes/.+\\.ya?ml$",
+      "apps/.*\\.ya?ml$",
+      "infrastructure/.*\\.ya?ml$",
+      "cluster/.*\\.ya?ml$"
+    ]
+  },
+  "helm-values": {
+    "fileMatch": [
+      "kubernetes/.+\\.ya?ml$",
+      "apps/.*\\.ya?ml$",
+      "infrastructure/.*\\.ya?ml$",
+      "cluster/.*\\.ya?ml$"
+    ]
+  },
+  "kubernetes": {
+    "fileMatch": [
+      "ansible/.+\\.ya?ml.j2$",
+      "kubernetes/.+\\.ya?ml$",
+      "apps/.*\\.ya?ml$",
+      "infrastructure/.*\\.ya?ml$",
+      "cluster/.*\\.ya?ml$"
+    ]
+  },
+  "regexManagers": [
+    {
+      "description": "Process various other dependencies",
+      "fileMatch": [
+        "ansible/.+\\.ya?ml$",
+        "kubernetes/.+\\.ya?ml$",
+        "apps/.*\\.ya?ml$",
+        "infrastructure/.*\\.ya?ml$",
+        "cluster/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>\\S+))?\n.*?\"(?<currentValue>.*)\"\n"
+      ],
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}"
+    }
+  ]
+}

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Auto merge GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "branch",
+      "ignoreTests": true,
+      "matchUpdateTypes": ["minor", "patch", "digest"]
+    },
+    {
+      "description": "Auto merge container digests",
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "branch",
+      "ignoreTests": true,
+      "matchUpdateTypes": ["digest"]
+    }
+  ]
+}

--- a/.github/renovate/commitMessage.json5
+++ b/.github/renovate/commitMessage.json5
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newVersion}}",
+  "commitMessageSuffix": "",
+  "packageRules": [
+    {
+      "matchDatasources": ["helm"],
+      "commitMessageTopic": "chart {{depName}}"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "commitMessageTopic": "image {{depName}}"
+    }
+  ]
+}

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Flux Group",
+      "groupName": "Flux",
+      "matchPackagePatterns": ["flux"],
+      "matchDatasources": ["docker", "github-tags"],
+      "versioning": "semver",
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} group"
+      },
+      "separateMinorPatch": true
+    }
+  ]
+}

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "labels": ["type/major"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "labels": ["type/minor"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "labels": ["type/patch"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "addLabels": ["renovate/container"]
+    },
+    {
+      "matchDatasources": ["helm"],
+      "addLabels": ["renovate/helm"]
+    },
+    {
+      "matchDatasources": ["galaxy", "galaxy-collection"],
+      "addLabels": ["renovate/ansible"]
+    },
+    {
+      "matchDatasources": ["github-releases", "github-tags"],
+      "addLabels": ["renovate/github-release"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "addLabels": ["renovate/github-action"]
+    }
+  ]
+}

--- a/.github/renovate/semanticCommits.json5
+++ b/.github/renovate/semanticCommits.json5
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat(container)!: "
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "container"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "container"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "container"
+    },
+    {
+      "matchDatasources": ["helm"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat(helm)!: "
+    },
+    {
+      "matchDatasources": ["helm"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "helm"
+    },
+    {
+      "matchDatasources": ["helm"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "helm"
+    },
+    {
+      "matchDatasources": ["galaxy", "galaxy-collection"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat(ansible)!: "
+    },
+    {
+      "matchDatasources": ["galaxy", "galaxy-collection"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "ansible"
+    },
+    {
+      "matchDatasources": ["galaxy", "galaxy-collection"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "ansible"
+    },
+    {
+      "matchDatasources": ["github-releases", "github-tags"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat(github-release)!: "
+    },
+    {
+      "matchDatasources": ["github-releases", "github-tags"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "github-release"
+    },
+    {
+      "matchDatasources": ["github-releases", "github-tags"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "github-release"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "feat(github-action)!: "
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "github-action"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "github-action"
+    }
+  ]
+}

--- a/clusters/development/infrastructure.yaml
+++ b/clusters/development/infrastructure.yaml
@@ -11,7 +11,23 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./infrastructure/controllers
+  path: ./infrastructure/base/controllers
+  prune: true
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-controllers
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/development/controllers
   prune: true
   wait: true
 ---
@@ -29,10 +45,22 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./infrastructure/configs
+  path: ./infrastructure/base/configs
   prune: true
-  # patches:
-  #  - patch: |
-  #      - op: replace
-  #        path: /spec/path
-  #        value: ./
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-controllers
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/development/configs
+  prune: true

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -11,7 +11,23 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./infrastructure/controllers
+  path: ./infrastructure/base/controllers
+  prune: true
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-controllers
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/staging/controllers
   prune: true
   wait: true
 ---
@@ -29,10 +45,22 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./infrastructure/configs
+  path: ./infrastructure/base/configs
   prune: true
-  # patches:
-  #  - patch: |
-  #      - op: replace
-  #        path: /spec/path
-  #        value: ./
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-controllers
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/staging/configs
+  prune: true

--- a/infrastructure/configs/cluster-issuers.yaml
+++ b/infrastructure/configs/cluster-issuers.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: cert-manager-secret
-    namespace: cert-manager
+  name: cert-manager-secret
+  namespace: cert-manager
 stringData:
-    api-key: "${SECRET_CLOUDFLARE_KEY}"
+  api-key: "${SECRET_CLOUDFLARE_KEY}"
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/infrastructure/configs/cluster-issuers.yaml
+++ b/infrastructure/configs/cluster-issuers.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cert-manager-secret
+    namespace: cert-manager
+stringData:
+    api-key: "${SECRET_CLOUDFLARE_KEY}"
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: "${SECRET_CLOUDFLARE_EMAIL}"
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+      - dns01:
+          cloudflare:
+            email: "${SECRET_CLOUDFLARE_EMAIL}"
+            apiKeySecretRef:
+              name: cert-manager-secret
+              key: api-key
+        selector:
+          dnsZones:
+            - "${SECRET_DOMAIN}"
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: "${SECRET_CLOUDFLARE_EMAIL}"
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - dns01:
+          cloudflare:
+            email: "${SECRET_CLOUDFLARE_EMAIL}"
+            apiKeySecretRef:
+              name: cert-manager-secret
+              key: api-key
+        selector:
+          dnsZones:
+            - "${SECRET_DOMAIN}"

--- a/infrastructure/configs/kustomization.yaml
+++ b/infrastructure/configs/kustomization.yaml
@@ -2,4 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cluster-issuers.yaml
   - cluster-secret-store.yaml
+  - metallb.yaml
+  - nginx-certificates.yaml
+  - rook-ceph-cluster.yaml

--- a/infrastructure/configs/metallb.yaml
+++ b/infrastructure/configs/metallb.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-ip
+  namespace: networking
+spec:
+  ipAddressPools:
+    - default-pool
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: networking
+spec:
+  addresses:
+    - "${METALLB_LB_RANGE}"

--- a/infrastructure/configs/nginx-certificates.yaml
+++ b/infrastructure/configs/nginx-certificates.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "${SECRET_DOMAIN/./-}-production"
+  namespace: nginx-ingress
+spec:
+  secretName: "${SECRET_DOMAIN/./-}-production-tls"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "${SECRET_DOMAIN}"
+  dnsNames:
+    - "${SECRET_DOMAIN}"
+    - "*.${SECRET_DOMAIN}"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "${SECRET_DOMAIN/./-}-staging"
+  namespace: nginx-ingress
+spec:
+  secretName: "${SECRET_DOMAIN/./-}-staging-tls"
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+  commonName: "${SECRET_DOMAIN}"
+  dnsNames:
+    - "${SECRET_DOMAIN}"
+    - "*.${SECRET_DOMAIN}"

--- a/infrastructure/configs/rook-ceph-cluster.yaml
+++ b/infrastructure/configs/rook-ceph-cluster.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: rook-ceph-cluster
+      version: v1.14.3
+      sourceRef:
+        kind: HelmRepository
+        name: rook-ceph
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    timeout: 1h
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    timeout: 1h
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    mon:
+      count: 3
+      allowMultiplePerNode: false
+    monitoring:
+      enabled: true
+      createPrometheusRules: true
+      rulesNamespaceOverride: monitoring
+    ingress:
+      dashboard:
+        ingressClassName: nginx
+        annotations:
+          nginx.ingress.kubernetes.io/whitelist-source-range: |
+            10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+          hajimari.io/appName: "Rook"
+          hajimari.io/icon: mdi:chess-rook
+        host:
+          name: &host "rook.${SECRET_DOMAIN}"
+          path: /
+        tls:
+          - hosts:
+              - *host
+    toolbox:
+      enabled: true
+    configOverride: |
+      [global]
+      bdev_enable_discard = true
+      bdev_async_discard = true
+    cephClusterSpec:
+      network:
+        provider: host
+        connections:
+          compression:
+            # TODO: Test out enabling this on next cluster rebuild
+            enabled: false
+      crashCollector:
+        disable: false
+      dashboard:
+        enabled: true
+        urlPrefix: /
+        ssl: false
+      storage:
+        useAllNodes: true
+        useAllDevices: true
+        onlyApplyOSDPlacement: false
+        config:
+          osdsPerDevice: "1"
+    cephBlockPools:
+      - name: ceph-blockpool
+        spec:
+          failureDomain: host
+          replicated:
+            size: 3
+        storageClass:
+          enabled: true
+          name: ceph-block
+          # isDefault: true
+          reclaimPolicy: Delete
+          allowVolumeExpansion: true
+          parameters:
+            imageFormat: "2"
+            imageFeatures: layering
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+            csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+            csi.storage.k8s.io/fstype: ext4
+    cephFileSystems:
+      - name: ceph-filesystem
+        spec:
+          metadataPool:
+            replicated:
+              size: 3
+          dataPools:
+            - failureDomain: host
+              replicated:
+                size: 3
+              name: data0
+          metadataServer:
+            activeCount: 1
+            activeStandby: true
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 4Gi
+              limits:
+                memory: 4Gi
+        storageClass:
+          enabled: true
+          isDefault: false
+          name: ceph-filesystem
+          pool: data0
+          reclaimPolicy: Delete
+          allowVolumeExpansion: true
+          parameters:
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+            csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+            csi.storage.k8s.io/fstype: ext4
+    cephObjectStores:
+      - name: ceph-objectstore
+        spec:
+          metadataPool:
+            failureDomain: host
+            replicated:
+              size: 3
+          dataPool:
+            failureDomain: host
+            erasureCoded:
+              dataChunks: 2
+              codingChunks: 1
+          preservePoolsOnDelete: true
+          gateway:
+            port: 80
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            instances: 1
+          healthCheck:
+            bucket:
+              interval: 60s
+        storageClass:
+          enabled: true
+          name: ceph-bucket
+          reclaimPolicy: Delete
+          parameters:
+            region: us-east-1

--- a/infrastructure/controllers/cert-manager.yaml
+++ b/infrastructure/controllers/cert-manager.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: cert-manager
+      version: v1.14.5
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    installCRDs: true
+    extraArgs:
+      - --dns01-recursive-nameservers=1.1.1.1:53,9.9.9.9:53
+      - --dns01-recursive-nameservers-only
+    podDnsPolicy: None
+    podDnsConfig:
+      nameservers:
+        - "1.1.1.1"
+        - "9.9.9.9"
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true
+        prometheusInstance: monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager.rules
+  namespace: cert-manager
+spec:
+  groups:
+    - name: cert-manager
+      rules:
+        - alert: CertManagerAbsent
+          expr: |
+            absent(up{job="cert-manager"})
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            description:
+              "New certificates will not be able to be minted, and existing
+              ones can't be renewed until cert-manager is back."
+            runbook_url: https://gitlab.com/uneeq-oss/cert-manager-mixin/-/blob/master/RUNBOOK.md#certmanagerabsent
+            summary: "Cert Manager has dissapeared from Prometheus service discovery."
+    - name: certificates
+      rules:
+        - alert: CertManagerCertExpirySoon
+          expr: |
+            avg by (exported_namespace, namespace, name) (
+            certmanager_certificate_expiration_timestamp_seconds - time())
+              < (21 * 24 * 3600)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            description:
+              "The domain that this cert covers will be unavailable after
+              {{ $value | humanizeDuration }}. Clients using endpoints that this cert
+              protects will start to fail in {{ $value | humanizeDuration }}."
+            runbook_url: https://gitlab.com/uneeq-oss/cert-manager-mixin/-/blob/master/RUNBOOK.md#certmanagercertexpirysoon
+            summary:
+              "The cert {{ $labels.name }} is {{ $value | humanizeDuration }}
+              from expiry, it should have renewed over a week ago."
+        - alert: CertManagerCertNotReady
+          expr: |
+            max by (name, exported_namespace, namespace, condition) (
+            certmanager_certificate_ready_status{condition!="True"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            description:
+              "This certificate has not been ready to serve traffic for at least
+              10m. If the cert is being renewed or there is another valid cert, the ingress
+              controller _may_ be able to serve that instead."
+            runbook_url: https://gitlab.com/uneeq-oss/cert-manager-mixin/-/blob/master/RUNBOOK.md#certmanagercertnotready
+            summary: "The cert {{ $labels.name }} is not ready to serve traffic."
+        - alert: CertManagerHittingRateLimits
+          expr: |
+            sum by (host) (rate(certmanager_http_acme_client_request_count{status="429"}[5m]))
+              > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            description:
+              "Depending on the rate limit, cert-manager may be unable to generate
+              certificates for up to a week."
+            runbook_url: https://gitlab.com/uneeq-oss/cert-manager-mixin/-/blob/master/RUNBOOK.md#certmanagerhittingratelimits
+            summary: "Cert manager hitting LetsEncrypt rate limits."

--- a/infrastructure/controllers/external-dns.yaml
+++ b/infrastructure/controllers/external-dns.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-    name: external-dns-secret
-    namespace: external-dns
+  name: external-dns-secret
+  namespace: external-dns
 stringData:
-    email: "${SECRET_CLOUDFLARE_EMAIL}"
-    api-key: "${SECRET_CLOUDFLARE_KEY}"
+  email: "${SECRET_CLOUDFLARE_EMAIL}"
+  api-key: "${SECRET_CLOUDFLARE_KEY}"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/infrastructure/controllers/external-dns.yaml
+++ b/infrastructure/controllers/external-dns.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: external-dns-secret
+    namespace: external-dns
+stringData:
+    email: "${SECRET_CLOUDFLARE_EMAIL}"
+    api-key: "${SECRET_CLOUDFLARE_KEY}"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app external-dns
+  namespace: networking
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: external-dns
+      version: 1.14.4
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: *app
+    provider: cloudflare
+    env:
+      - name: CF_API_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: external-dns-secret
+            key: email
+      - name: CF_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: external-dns-secret
+            key: api-key
+    extraArgs:
+      - --annotation-filter=external-dns.alpha.kubernetes.io/target
+      - --cloudflare-proxied
+      - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
+      - --crd-source-kind=DNSEndpoint
+    policy: sync
+    sources: ["crd", "ingress"]
+    txtPrefix: k8s.
+    txtOwnerId: default
+    domainFilters: ["${SECRET_DOMAIN}"]
+    serviceMonitor:
+      enabled: true
+    podAnnotations:
+      secret.reloader.stakater.com/reload: external-dns-secret

--- a/infrastructure/controllers/external-secrets.yaml
+++ b/infrastructure/controllers/external-secrets.yaml
@@ -17,7 +17,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-secrets
-  namespace: kube-system
+  namespace: external-secrets
 spec:
   interval: 15m
   chart:

--- a/infrastructure/controllers/k8s-gateway.yaml
+++ b/infrastructure/controllers/k8s-gateway.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-gateway
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: k8s-gateway
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://ori-edge.github.io/k8s_gateway/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8s-gateway
+  namespace: k8s-gateway
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: k8s-gateway
+      version: 2.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: k8s-gateway
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    fullnameOverride: k8s-gateway
+    domain: "${SECRET_DOMAIN}"
+    ttl: 1
+    service:
+      type: LoadBalancer
+      port: 53
+      annotations:
+        metallb.universe.tf/loadBalancerIPs: "${METALLB_K8S_GATEWAY_ADDR}"
+      externalTrafficPolicy: Local

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -4,4 +4,10 @@ kind: Kustomization
 metadata:
   name: infra-controllers
 resources:
+  - cert-manager.yaml
+  - external-dns.yaml
   - external-secrets.yaml
+  - k8s-gateway.yaml
+  - metallb.yaml
+  - nginx-ingress.yaml
+  - rook-ceph.yaml

--- a/infrastructure/controllers/metallb.yaml
+++ b/infrastructure/controllers/metallb.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metallb
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://metallb.github.io/metallb
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metallb
+  namespace: metallb
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: metallb
+      version: 0.14.5
+      sourceRef:
+        kind: HelmRepository
+        name: metallb
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    crds:
+      enabled: true

--- a/infrastructure/controllers/nginx-ingress.yaml
+++ b/infrastructure/controllers/nginx-ingress.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-ingress
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes.github.io/ingress-nginx
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nginx-ingress
+  namespace: nginx-ingress
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: 4.10.1
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    controller:
+      allowSnippetAnnotations: true
+      extraEnvs:
+        - name: TZ
+          value: "${TIMEZONE}"
+      service:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: "ingress.${SECRET_DOMAIN}"
+        loadBalancerIP: "${METALLB_INGRESS_ADDR}"
+        externalTrafficPolicy: Local
+      publishService:
+        enabled: true
+      ingressClassResource:
+        default: true
+      config:
+        client-header-timeout: 120
+        client-body-buffer-size: "100M"
+        client-body-timeout: 120
+        custom-http-errors: 400,401,403,404,500,502,503,504
+        enable-brotli: "true"
+        hsts-max-age: "31449600"
+        keep-alive: 120
+        keep-alive-requests: 10000
+        proxy-body-size: "100M"
+        ssl-protocols: "TLSv1.3 TLSv1.2"
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          namespace: networking
+          namespaceSelector:
+            any: true
+      extraArgs:
+        default-ssl-certificate: "nginx-ingress/${SECRET_DOMAIN/./-}-production-tls"
+      resources:
+        requests:
+          cpu: 10m
+          memory: 250Mi
+        limits:
+          memory: 500Mi
+    defaultBackend:
+      enabled: true
+      image:
+        repository: ghcr.io/tarampampam/error-pages
+        tag: 2.27.0
+      extraEnvs:
+        - { name: TEMPLATE_NAME, value: lost-in-space }
+        - { name: SHOW_DETAILS, value: "false" }

--- a/infrastructure/controllers/rook-ceph.yaml
+++ b/infrastructure/controllers/rook-ceph.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: rook-ceph
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://charts.rook.io/release
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: rook-ceph
+      version: v1.14.3
+      sourceRef:
+        kind: HelmRepository
+        name: rook-ceph
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    timeout: 30m
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    timeout: 30m
+    remediation:
+      retries: 10
+  uninstall:
+    keepHistory: false
+  values:
+    monitoring:
+      enabled: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Brings the following Infrastructure components:

- Cert-Manager
- External-DNS
- External-Secrets (updates)
- k8s-gateway
- metallb
- nginx-ingress
- rook-ceph

and their various configurations.

Also updates renovate config to ignore staging and production, amongst other changes (implements renovate config from CloudHub-Cluster)